### PR TITLE
Add raw component

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -436,12 +436,13 @@ class Job(object):
             else:
                 return utcparse(as_text(date_str))
 
-        self.raw = obj.get('raw', False)
+        self.raw = obj.get('raw', None)
         if self.raw:
             # import logging; logging.basicConfig(level=logging.DEBUG)
             # logger = logging.getLogger(__name__)
             # logger.info(type(self.raw))
             # logger.info(self.raw)
+            self.raw = as_text(self.raw)
             self._func_name = obj.get('func_name').decode()
             self._args = (obj.get('arg'),)
             self._kwargs = {}

--- a/rq/job.py
+++ b/rq/job.py
@@ -639,7 +639,10 @@ class Job(object):
         return self._result
 
     def _execute(self):
-        return self.func(*self.args, **self.kwargs)
+        if self.raw:
+            return self.func(*self.args, raw=self.raw)
+        else:
+            return self.func(*self.args, **self.kwargs)
 
     def get_ttl(self, default_ttl=None):
         """Returns ttl for a job that determines how long a job will be

--- a/rq/job.py
+++ b/rq/job.py
@@ -335,6 +335,7 @@ class Job(object):
         self._dependency_id = None
         self.meta = {}
         self.raw = False
+        self.arg = None
 
     def __repr__(self):  # noqa  # pragma: no cover
         return '{0}({1!r}, enqueued_at={2!r})'.format(self.__class__.__name__,

--- a/rq/job.py
+++ b/rq/job.py
@@ -225,7 +225,7 @@ class Job(object):
         # logger = logging.getLogger(__name__)
         # logger.info(f"raw: {self.raw}")
         if self.raw:
-            un_encoded_data = self.data.split(b' ')
+            un_encoded_data = self.data.split(b' ', maxsplit=1)
             self._func_name = un_encoded_data[0].decode()
             self._instance = None
             self._args = (un_encoded_data[1],)

--- a/rq/job.py
+++ b/rq/job.py
@@ -505,7 +505,6 @@ class Job(object):
             except:
                 obj['result'] = 'Unpickleable return value'
         if self.exc_info is not None:
-            # obj['exc_info'] = zlib.compress(str(self.exc_info).encode('utf-8'))
             obj['exc_info'] = str(self.exc_info).encode('utf-8')
         if self.timeout is not None:
             obj['timeout'] = self.timeout

--- a/rq/job.py
+++ b/rq/job.py
@@ -629,11 +629,6 @@ class Job(object):
 
     def _execute(self):
         if self.raw:
-            # import logging; logging.basicConfig(level=logging.DEBUG)
-            # logging.info(type(self.raw))
-            # logging.info(self.args)
-            # logging.info(self.kwargs)
-            # logging.info(self.args)
             return self.func(*self.args, raw=self.raw)
         else:
             return self.func(*self.args, **self.kwargs)

--- a/rq/job.py
+++ b/rq/job.py
@@ -436,7 +436,6 @@ class Job(object):
                 return utcparse(as_text(date_str))
 
         self.raw = obj.get('raw', False)
-        self.raw = bool(self.raw)
         if self.raw:
             # import logging; logging.basicConfig(level=logging.DEBUG)
             # logger = logging.getLogger(__name__)

--- a/rq/job.py
+++ b/rq/job.py
@@ -434,11 +434,7 @@ class Job(object):
                 return utcparse(as_text(date_str))
 
         self.raw = obj.get('raw', None)
-        if self.raw:
-            # import logging; logging.basicConfig(level=logging.DEBUG)
-            # logger = logging.getLogger(__name__)
-            # logger.info(type(self.raw))
-            # logger.info(self.raw)
+        if self.raw is not None:
             self.raw = as_text(self.raw)
             self._func_name = obj.get('func_name').decode()
             self._args = (obj.get('arg'),)

--- a/rq/job.py
+++ b/rq/job.py
@@ -109,6 +109,7 @@ class Job(object):
         if raw:
             assert len(args) == 1
             assert len(kwargs) == 0
+            assert type(args[0]) == bytes
 
         job = cls(connection=connection)
         if id is not None:
@@ -220,10 +221,6 @@ class Job(object):
         return import_attribute(self.func_name)
 
     def _unpickle_data(self):
-        # import logging
-        # logging.basicConfig(level=logging.DEBUG)
-        # logger = logging.getLogger(__name__)
-        # logger.info(f"raw: {self.raw}")
         self._func_name, self._instance, self._args, self._kwargs = unpickle(self.data)
 
     @property

--- a/rq/job.py
+++ b/rq/job.py
@@ -109,7 +109,7 @@ class Job(object):
         if raw:
             assert len(args) == 1
             assert len(kwargs) == 0
-        
+
         job = cls(connection=connection)
         if id is not None:
             job.set_id(id)

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -310,10 +310,10 @@ class Queue(object):
             assert args == (), 'Extra positional arguments cannot be used when using explicit args and kwargs'  # noqa
             args = kwargs.pop('args', None)
             kwargs = kwargs.pop('kwargs', None)
-        
+
         if raw:
             # If raw flag is true we leave the pickling up to the end user
-            # we ensure there is only one arg. 
+            # we ensure there is only one arg.
             assert len(args) == 1
             assert len(kwargs) == 0
             assert type(args[0]) == bytes

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -211,7 +211,7 @@ class Queue(object):
 
     def enqueue_call(self, func, args=None, kwargs=None, timeout=None,
                      result_ttl=None, ttl=None, description=None,
-                     depends_on=None, job_id=None, at_front=False, meta=None):
+                     depends_on=None, job_id=None, at_front=False, meta=None, raw=False):
         """Creates a job to represent the delayed function call and enqueues
         it.
 
@@ -227,7 +227,7 @@ class Queue(object):
             func, args=args, kwargs=kwargs, connection=self.connection,
             result_ttl=result_ttl, ttl=ttl, status=JobStatus.QUEUED,
             description=description, depends_on=depends_on,
-            timeout=timeout, id=job_id, origin=self.name, meta=meta)
+            timeout=timeout, id=job_id, origin=self.name, meta=meta, raw=raw)
 
         # If job depends on an unfinished job, register itself on it's
         # parent's dependents instead of enqueueing it.
@@ -304,16 +304,24 @@ class Queue(object):
         job_id = kwargs.pop('job_id', None)
         at_front = kwargs.pop('at_front', False)
         meta = kwargs.pop('meta', None)
+        raw = kwargs.pop('raw', False)
 
         if 'args' in kwargs or 'kwargs' in kwargs:
             assert args == (), 'Extra positional arguments cannot be used when using explicit args and kwargs'  # noqa
             args = kwargs.pop('args', None)
             kwargs = kwargs.pop('kwargs', None)
+        
+        if raw:
+            # If raw flag is true we leave the pickling up to the end user
+            # we ensure there is only one arg. 
+            assert len(args) == 1
+            assert len(kwargs) == 0
+            assert type(args[0]) == bytes
 
         return self.enqueue_call(func=f, args=args, kwargs=kwargs,
                                  timeout=timeout, result_ttl=result_ttl, ttl=ttl,
                                  description=description, depends_on=depends_on,
-                                 job_id=job_id, at_front=at_front, meta=meta)
+                                 job_id=job_id, at_front=at_front, meta=meta, raw=raw)
 
     def enqueue_job(self, job, pipeline=None, at_front=False):
         """Enqueues a job for delayed execution.

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -26,6 +26,15 @@ def say_hello(name=None):
         name = 'Stranger'
     return 'Hi there, %s!' % (name,)
 
+def say_raw_hello(name=None, raw=False):
+    """A job with a single argument and a return value."""
+    if not raw:
+        if name is None:
+            name = 'Stranger'
+    else:
+        name = name.decode('utf-8')
+    return 'Hi there, %s!' % (name,)
+
 
 def say_hello_unicode(name=None):
     """A job with a single argument and a return value."""

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -109,7 +109,7 @@ class TestJob(RQTestCase):
 
     def test_create_typical_raw_job(self):
         """Creation of jobs for function calls."""
-        job = Job.create('tests.fixtures.say_raw_hello', args=(3,), raw='yes')
+        job = Job.create('tests.fixtures.say_raw_hello', args=(b"Ahmad",), raw='yes')
 
         # Jobs have a random UUID
         self.assertIsNotNone(job.id)
@@ -119,7 +119,7 @@ class TestJob(RQTestCase):
 
         # Job data is set...
         self.assertEqual(job.func, fixtures.say_raw_hello)
-        self.assertEqual(job.args, (3,))
+        self.assertEqual(job.args, (b"Ahmad",))
         self.assertEqual(job.kwargs, {})
 
         # ...but metadata is not

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -85,6 +85,8 @@ class TestJob(RQTestCase):
         self.assertRaises(AssertionError, Job.create, 
             'tests.fixtures.some_calculation', args=(1,2), raw=True)
         self.assertRaises(AssertionError, Job.create, 
+            'tests.fixtures.some_calculation', args=(1,), raw=True)
+        self.assertRaises(AssertionError, Job.create, 
             'tests.fixtures.some_calculation', kwargs=dict(x=1,y=2), raw=True)
 
     def test_create_typical_job(self):
@@ -128,7 +130,7 @@ class TestJob(RQTestCase):
         self.assertIsNone(job.result)
     
         # ... raw flag is present
-        self.assertIsNotNone(job.raw)
+        self.assertEquals(job.raw, 'yes')
 
     def test_create_instance_method_job(self):
         """Creation of jobs for instance methods."""

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -109,7 +109,7 @@ class TestJob(RQTestCase):
 
     def test_create_typical_raw_job(self):
         """Creation of jobs for function calls."""
-        job = Job.create('tests.fixtures.say_hello', args=(3,), raw=True)
+        job = Job.create('tests.fixtures.say_raw_hello', args=(3,), raw='yes')
 
         # Jobs have a random UUID
         self.assertIsNotNone(job.id)
@@ -118,7 +118,7 @@ class TestJob(RQTestCase):
         self.assertIsNone(job.instance)
 
         # Job data is set...
-        self.assertEqual(job.func, fixtures.say_hello)
+        self.assertEqual(job.func, fixtures.say_raw_hello)
         self.assertEqual(job.args, (3,))
         self.assertEqual(job.kwargs, {})
 
@@ -151,10 +151,10 @@ class TestJob(RQTestCase):
 
     def test_create_raw_job_from_string_function(self):
         """Creation of jobs using string specifier."""
-        job = Job.create(func='tests.fixtures.say_hello', args=(b'World',), raw=True)
+        job = Job.create(func='tests.fixtures.say_raw_hello', args=(b'World',), raw=True)
 
         # Job data is set
-        self.assertEqual(job.func, fixtures.say_hello)
+        self.assertEqual(job.func, fixtures.say_raw_hello)
         self.assertIsNone(job.instance)
         self.assertEqual(job.args, (b'World',))
         self.assertEqual(job.raw, True)
@@ -203,7 +203,7 @@ class TestJob(RQTestCase):
 
     def test_raw_save(self):  # noqa
         """Storing jobs."""
-        job = Job.create(func='tests.fixtures.say_hello', args=(b'Ahmad',), raw='yes')
+        job = Job.create(func='tests.fixtures.say_raw_hello', args=(b'Ahmad',), raw='yes')
 
         # Saving creates a Redis hash
         self.assertEqual(self.testconn.exists(job.key), False)
@@ -214,7 +214,7 @@ class TestJob(RQTestCase):
         arg = self.testconn.hget(job.key, 'arg')
         raw = self.testconn.hget(job.key, 'raw')
         
-        self.assertEqual(func_name, b'tests.fixtures.say_hello')
+        self.assertEqual(func_name, b'tests.fixtures.say_raw_hello')
         self.assertEqual(arg, b'Ahmad')
         self.assertIsNotNone(raw)
 
@@ -239,7 +239,7 @@ class TestJob(RQTestCase):
         """Fetching jobs."""
         # Prepare test
         self.testconn.hset('rq:job:some_id', 'func_name',
-                           b'tests.fixtures.say_hello')
+                           b'tests.fixtures.say_raw_hello')
         self.testconn.hset('rq:job:some_id', 'arg',
                            b'Ahmad')
         self.testconn.hset('rq:job:some_id', 'raw', 'yes')
@@ -249,7 +249,7 @@ class TestJob(RQTestCase):
         # Fetch returns a job
         job = Job.fetch('some_id')
         self.assertEqual(job.id, 'some_id')
-        self.assertEqual(job.func_name, 'tests.fixtures.say_hello')
+        self.assertEqual(job.func_name, 'tests.fixtures.say_raw_hello')
         self.assertIsNone(job.instance)
         self.assertEqual(job._args, (b'Ahmad',))
         self.assertEqual(job.kwargs, dict())
@@ -276,7 +276,7 @@ class TestJob(RQTestCase):
 
     def test_persistence_of_typical_raw_jobs(self):
         """Storing typical raw jobs."""
-        job = Job.create(func='tests.fixtures.say_hello', args=(b'Ahmad',), raw='yes')
+        job = Job.create(func='tests.fixtures.say_raw_hello', args=(b'Ahmad',), raw='yes')
         job.save()
 
         stored_date = self.testconn.hget(job.key, 'created_at').decode('utf-8')
@@ -568,7 +568,7 @@ class TestJob(RQTestCase):
 
     def test_raw_cleanup(self):
         """Test that jobs and results are expired properly."""
-        job = Job.create(func='tests.fixtures.say_hello', raw='yes')
+        job = Job.create(func='tests.fixtures.say_hello', args=(b'Ahmad',) ,raw='yes')
         job.save()
 
         # Jobs with negative TTLs don't expire


### PR DESCRIPTION
Add raw component for jobs. 
Removes reliance on python pickling. We can now add jobs to redis directly. 
